### PR TITLE
update github links from zkSNACKs to WalletWasabi org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This is Wasabi Wallet's open-source [documentation](https://docs.wasabiwallet.io
 Here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves some of the existing problems, and how you can use this tool to defend yourself.
 
 If you would like to support the project by educating other people, this documentation repository is the right place for your efforts!
-If you have a question regarding the documentation, please [open an issue](https://github.com/zkSNACKs/WasabiDoc/issues).
-If you have an answer to a question, please [open a pull request](https://github.com/zkSNACKs/WasabiDoc/pulls).
+If you have a question regarding the documentation, please [open an issue](https://github.com/WalletWasabi/WasabiDoc/issues).
+If you have an answer to a question, please [open a pull request](https://github.com/WalletWasabi/WasabiDoc/pulls).
 For more details on how to contribute, see the [contribution checklist](https://docs.wasabiwallet.io/building-wasabi/ContributionChecklist.html).
 
-If you need help regarding the software specifically, please check out [Discussions](https://github.com/zkSNACKs/WalletWasabi/discussions) in Wasabi Wallet's [main repository](https://github.com/zkSNACKs/WalletWasabi).
+If you need help regarding the software specifically, please check out [Discussions](https://github.com/WalletWasabi/WalletWasabi/discussions) in Wasabi Wallet's [main repository](https://github.com/WalletWasabi/WalletWasabi).
 
 [![Build Status](https://dev.azure.com/zkSNACKs/WasabiDoc/_apis/build/status/zkSNACKs.WasabiDoc?branchName=master)](https://dev.azure.com/zkSNACKs/WasabiDoc/_build/latest?definitionId=4&branchName=master)
 
@@ -18,17 +18,17 @@ If you need help regarding the software specifically, please check out [Discussi
 
 # 🏛️ The pillars of the documentation
 
-* ## [Getting Started](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/getting-started/)
+* ## [Getting Started](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/getting-started/)
   * Getting started guide.
-* ## [Why Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/why-wasabi/)
+* ## [Why Wasabi](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/why-wasabi/)
   * Why privacy is important.
-* ## [Using Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/using-wasabi/)
+* ## [Using Wasabi](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/using-wasabi/)
   * How to use Wasabi Wallet.
-* ## [Building Wasabi](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/building-wasabi/)
+* ## [Building Wasabi](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/building-wasabi/)
   * How to contribute to Wasabi.
-* ## [Wasabi FAQ](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/FAQ/)
+* ## [Wasabi FAQ](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/FAQ/)
   * Frequently asked questions.
-* ## [Wasabi Glossary](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/glossary/)
+* ## [Wasabi Glossary](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/glossary/)
   * Explanations of common words.
 
 ---
@@ -52,7 +52,7 @@ Not only do we appreciate everyone's contribution, but we desperately need it!
 ## VuePress
 
 The [Wasabi documentation website](https://docs.wasabiwallet.io) is built using an open-source static site generator called VuePress.
-Its [configuration](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/.vuepress/config.js) and [theme](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/.vuepress/styles) are extremely customizable, and it offers great defaults out-of-the-box.
+Its [configuration](https://github.com/WalletWasabi/WasabiDoc/blob/master/docs/.vuepress/config.js) and [theme](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/.vuepress/styles) are extremely customizable, and it offers great defaults out-of-the-box.
 Check out the [VuePress website](https://v1.vuepress.vuejs.org/) for details on how to use it.
 
 To contribute to the content of the website, you can make PRs related to the markdown files in the `/docs/` directory, and if merged, the changes will automatically be integrated into the documentation website by VuePress.
@@ -76,7 +76,7 @@ Please consider this repository structure for hyperlinks, and use relative links
 
 ## Embedding images
 
-The images are stored in the [`/docs/.vuepress/public/`](https://github.com/zkSNACKs/WasabiDoc/tree/master/docs/.vuepress/public) directory.
+The images are stored in the [`/docs/.vuepress/public/`](https://github.com/WalletWasabi/WasabiDoc/tree/master/docs/.vuepress/public) directory.
 They can be embedded via the following markdown tags:
 
 ```
@@ -149,7 +149,7 @@ answer answer answer.
 ## Variables
 
 To have a single place to maintain universal strings like the current Wasabi version number, we use variables in the Markdown (i.e.  `${currentVersion}`and `${zksnacksPublicKeyFingerprint}`).
-These variables are managed in [`docs/.vuepress/config.ts`](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/.vuepress/config.ts).
+These variables are managed in [`docs/.vuepress/config.ts`](https://github.com/WalletWasabi/WasabiDoc/blob/master/docs/.vuepress/config.ts).
 Occurrences of `${variableName}` get substituted before the Markdown is processed.
 
 # Build the Documentation Locally

--- a/docs/FAQ/FAQ-Contribution.md
+++ b/docs/FAQ/FAQ-Contribution.md
@@ -19,7 +19,7 @@ Thank you for considering to support this beautiful libre and open-source projec
 It is the responsibility of everyone using the software to contribute to its growth.
 Your help is deeply appreciated, and very much needed!
 First please read the [contribution checklist](/building-wasabi/ContributionChecklist.md) to get introduced to the project and to start out in the right direction.
-Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg) and check out our [GitHub repository](https://github.com/zkSNACKs/WalletWasabi), so that you can stay up-to-date with the latest contributions.
+Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg) and check out our [GitHub repository](https://github.com/WalletWasabi/WalletWasabi), so that you can stay up-to-date with the latest contributions.
 
 ### Is there a bounty program?
 
@@ -35,16 +35,16 @@ Code is speech, and can never be perfect.
 Thus it is expected that there are many known and unknown bugs, quirks and issues in Wasabi.
 Such a complex software requires constant and rigorous review by the developers and the users, this is everyone's responsibility working with Wasabi.
 
-When you stumble upon an issue that needs fixing, please first check the open [issues](https://github.com/zkSNACKs/WalletWasabi/issues/) and [pull requests](https://github.com/zkSNACKs/WalletWasabi/pulls) if there is already someone working on it.
+When you stumble upon an issue that needs fixing, please first check the open [issues](https://github.com/WalletWasabi/WalletWasabi/issues/) and [pull requests](https://github.com/WalletWasabi/WalletWasabi/pulls) if there is already someone working on it.
 If yes, then you can comment your situation and bug report under the open issue.
-If no, then please consider to [open a new issue](https://github.com/zkSNACKs/WalletWasabi/issues/new?template=bug-report.md) and give a detailed report on the problem.
+If no, then please consider to [open a new issue](https://github.com/WalletWasabi/WalletWasabi/issues/new?template=bug-report.md) and give a detailed report on the problem.
 It is especially helpful when you provide a step-by-step guide on how to reproduce what you have found.
 There is constantly a lot of work done to the code base, thus it's good to know which version of Wasabi, and what operating system you are using.
 In some cases it might be useful to see your logs, though please consider your privacy and encrypt this data properly in direct communication with the developers.
 
 :::danger
 If you find a bug that puts users' privacy or security at serious risk, please take great care with responsible disclosure!
-Send an email to [adam.ficsor73@gmail.com](mailto:adam.ficsor73@gmail.com), preferably using PGP encryption [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/zkSNACKs/WalletWasabi/blob/master/SECURITY.md).
+Send an email to [adam.ficsor73@gmail.com](mailto:adam.ficsor73@gmail.com), preferably using PGP encryption [21D7 CA45 565D BCCE BE45 115D B4B7 2266 C47E 075E](https://github.com/WalletWasabi/WalletWasabi/blob/master/SECURITY.md).
 :::
 
 ### How can I request a feature?
@@ -54,9 +54,9 @@ Yet there are also 1001 things that could be just a little better, or even quite
 The beauty and bane of libre and open-source software is that it is never complete, there is always more work to be done.
 
 Regardless if you are a new user of Wasabi, or a veteran black belt Wasabika, any suggestions on how to improve are very welcome.
-Please first check the existing [issues](https://github.com/zkSNACKs/WalletWasabi/issues/) and [pull requests](https://github.com/zkSNACKs/WalletWasabi/pulls) if someone has the same feature request as you.
+Please first check the existing [issues](https://github.com/WalletWasabi/WalletWasabi/issues/) and [pull requests](https://github.com/WalletWasabi/WalletWasabi/pulls) if someone has the same feature request as you.
 If yes, then you can comment your desired improvement under the open issue.
-If no, then please consider to [open a new issue](https://github.com/zkSNACKs/WalletWasabi/issues/new?template=feature-request.md) and give a detailed request.
+If no, then please consider to [open a new issue](https://github.com/WalletWasabi/WalletWasabi/issues/new?template=feature-request.md) and give a detailed request.
 It makes sense to first explain the problem you have in the incumbent version of Wasabi, this is the place to express your frustrations and annoyances.
 Then describe the solution that you have envisioned, with all the nuances and details of how this would fix your problem.
 To flesh our your argument, please consider alternatives and different approaches to this feature request.
@@ -66,8 +66,8 @@ To flesh our your argument, please consider alternatives and different approache
 You are already on the right track by first checking [this documentation](https://docs.wasabiwallet.io) for the knowledge you are seeking.
 It's likely that you are not the first person who has an issue or a question, and hopefully someone has curated the answer in here already.
 You can use the search function in the top navbar to look for a specific topic, and the sidebar menu as a table of content.
-You can also use our [GitHub Discussions](https://github.com/zkSNACKs/WalletWasabi/discussions/5185) to find solutions to different issues and to ask questions if necessary.
-If your trouble is specific to the code, then it might also be suitable to check the existing [GitHub issues](https://github.com/zkSNACKs/WalletWasabi/issues/) and open a new one.
+You can also use our [GitHub Discussions](https://github.com/WalletWasabi/WalletWasabi/discussions/5185) to find solutions to different issues and to ask questions if necessary.
+If your trouble is specific to the code, then it might also be suitable to check the existing [GitHub issues](https://github.com/WalletWasabi/WalletWasabi/issues/) and open a new one.
 
 ### What does the Wasabi project need help with?
 

--- a/docs/FAQ/FAQ-Installation.md
+++ b/docs/FAQ/FAQ-Installation.md
@@ -14,8 +14,8 @@
 You can find the recent version of the compiled packages for Linux, Windows and Mac available on the official [wasabiwallet.io](https://wasabiwallet.io).
 It's always best to download software directly from the official source acknowledged by the developers.
 In order to preserve your network level privacy from the very first step on, please consider visiting the Tor onion service [wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
-The old versions of the software can be found in the [releases](https://github.com/zksnacks/walletwasabi/releases) of the GitHub repository, [here](https://github.com/zksnacks/walletwasabi) you also find the libre & open source code for when you want to [build it yourself](/using-wasabi/BuildSource.md).
-Please take special care to verify the PGP signatures of zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
+The old versions of the software can be found in the [releases](https://github.com/WalletWasabi/walletwasabi/releases) of the GitHub repository, [here](https://github.com/WalletWasabi/walletwasabi) you also find the libre & open source code for when you want to [build it yourself](/using-wasabi/BuildSource.md).
+Please take special care to verify the PGP signatures of zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt) over the software packages and code commits.
 
 ### Why is it important to verify PGP signatures?
 
@@ -29,7 +29,7 @@ Wasabi is tailor made so that you do **not** have to trust anyone, but you have 
 
 With PGP signatures you can verify that the software package you download is actually the one by the developers.
 Every release of Wasabi is signed by [zkSNACKs](https://zksnacks.com/), the company behind Wasabi.
-You can verify that the PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) is actually the one of [zkSNACKs](https://pgp.key-server.io/search/zksnacks) by exploring the [web of trust](https://en.wikipedia.org/wiki/Web_of_trust).
+You can verify that the PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt) is actually the one of [zkSNACKs](https://pgp.key-server.io/search/zksnacks) by exploring the [web of trust](https://en.wikipedia.org/wiki/Web_of_trust).
 When you have a software package that was signed by this PGP public key, then you can be sure that this is an official release approved by zkSNACKs.
 This protects you against malicious man in the middle attacks where bad guys give you a fake version of Wasabi with malicious code.
 
@@ -53,7 +53,7 @@ For an in-depth guide for [Debian and Ubuntu](/using-wasabi/InstallPackage.md#de
 
 ![Download Wasabi Wallet for Debian](/DownloadDeb.png "Download Wasabi Wallet for Debian")
 
-Verify the signature of the package with `gpg --verify Wasabi-${currentVersion}.deb.asc Wasabi-${currentVersion}.deb` and ensure that the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Verify the signature of the package with `gpg --verify Wasabi-${currentVersion}.deb.asc Wasabi-${currentVersion}.deb` and ensure that the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt).
 
 Now install Wasabi with `sudo apt install ./Wasabi-${currentVersion}.deb`, and run it with `wassabee`.
 Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#debian-and-ubuntu).
@@ -66,7 +66,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 
 ![Download Wasabi Wallet for Linux](/DownloadTar.png "Download Wasabi Wallet for Linux")
 
-Verify the signature of the package with `gpg --verify Wasabi-${currentVersion}.tar.gz.asc Wasabi-${currentVersion}.tar.gz` and ensure that the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Verify the signature of the package with `gpg --verify Wasabi-${currentVersion}.tar.gz.asc Wasabi-${currentVersion}.tar.gz` and ensure that the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi with `sudo tar -pxzf Wasabi-${currentVersion}.tar.gz`, and run it with `./wassabee`.
 Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#other-linux).
 
@@ -80,7 +80,7 @@ The Wasabi package is signed and automatically verified on Windows upon installa
 
 ![Wasabi Wallet Windows signature verification](/InstallWindowsSignature.png "Wasabi Wallet Windows signature verification")
 
-Optionally, you can still verify the PGP signature of the package by `right-clicking on the signature file > More GpgEX options > Verify` and ensure the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Optionally, you can still verify the PGP signature of the package by `right-clicking on the signature file > More GpgEX options > Verify` and ensure the software was signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi by double-clicking the `.msi` file.
 Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#windows).
 
@@ -92,7 +92,7 @@ Check out the main documentation for a [step-by-step guide](/using-wasabi/Instal
 
 The Wasabi package is signed and automatically verified on macOS upon installation.
 
-Optionally, you can still verify the PGP signature of the package with `sudo gpg2 --verify Wasabi-${currentVersion}.dmg.asc` and ensure that the software has been signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+Optionally, you can still verify the PGP signature of the package with `sudo gpg2 --verify Wasabi-${currentVersion}.dmg.asc` and ensure that the software has been signed by zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt).
 Now install Wasabi by double-clicking the `.dmg` file.
 Check out the main documentation for a [step-by-step guide](/using-wasabi/InstallPackage.md#macos).
 
@@ -179,7 +179,7 @@ Downloading and installing the newer Wasabi package will overwrite the previous 
 So to upgrade Wasabi, simply download and install the new version like at first install.
 
 You can download the software build for the different operating systems on the main [website](https://wasabiwallet.io) or better over [Tor](http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion).
-For extra security, it is reccommended to also download the signatures of the build and verify them with [zkSNACKs' PGP public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
+For extra security, it is reccommended to also download the signatures of the build and verify them with [zkSNACKs' PGP public key](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt).
 For step-by-step instructions, follow [this guide](/using-wasabi/InstallPackage.md) or see this video: [![Watch the video](/Logo_without_text_with_bg_dark_with_yt.png)](https://youtu.be/DUc9A76rwX4)
 
 ### What does `Auto download new version` in the settings mean?
@@ -196,7 +196,7 @@ A new version will have to be installed manually.
 
 The software will automatically download the new version's installer upon a new release.
 After it is downloaded, the user can press "Update on Close" to run the installer when closing Wasabi.
-The installer is downloaded from [GitHub](https://github.com/zkSNACKs/WalletWasabi/).
+The installer is downloaded from [GitHub](https://github.com/WalletWasabi/WalletWasabi/).
 
 ## Advanced Installation
 
@@ -205,7 +205,7 @@ The installer is downloaded from [GitHub](https://github.com/zkSNACKs/WalletWasa
 If you cannot wait until the next release, and you want to experience the most cutting-edge version of Wasabi, then you can [build the source code](/using-wasabi/BuildSource.md).
 
 The only two required tools are [Git](https://git-scm.com/downloads) and [.NET ${dotnetVersion} SDK](https://dotnet.microsoft.com/download) for "Build apps".
-You can download every line of the Wasabi code by `git clone https://github.com/zkSNACKs/WalletWasabi.git`, this will create a new directory called `WalletWasabi`.
+You can download every line of the Wasabi code by `git clone https://github.com/WalletWasabi/WalletWasabi.git`, this will create a new directory called `WalletWasabi`.
 In order to build and run the Wallet software, change directory to `cd WalletWasabi/WalletWasabi.Fluent.Desktop`.
 Wasabi is written in C# with the .NET framework, and it is very easy to run it.
 Simply execute `dotnet run` from the `WalletWasabi.Fluent.Desktop` folder.
@@ -213,11 +213,11 @@ You can update the master branch with `git pull`.
 
 ### How can I verify the deterministic build?
 
-The guide for the deterministic builds can be found in the [WalletWasabi repository](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md).
+The guide for the deterministic builds can be found in the [WalletWasabi repository](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md).
 
 ### My antivirus marks Wasabi Wallet as a virus. Am I downloading the right software?
 
-After you have downloaded Wasabi from the [official website](https://wasabiwallet.io) or from the [official GitHub repository](https://github.com/zkSNACKs/WalletWasabi/releases), make sure you have [verified the PGP signatures](/FAQ/FAQ-Installation.md#how-can-i-verify-pgp-signatures).
+After you have downloaded Wasabi from the [official website](https://wasabiwallet.io) or from the [official GitHub repository](https://github.com/WalletWasabi/WalletWasabi/releases), make sure you have [verified the PGP signatures](/FAQ/FAQ-Installation.md#how-can-i-verify-pgp-signatures).
 
 If you have downloaded and verified digital signatures and your antivirus continues to report Wasabi as positive, you don't have to worry about anything; it is a false positive.
 

--- a/docs/FAQ/FAQ-Introduction.md
+++ b/docs/FAQ/FAQ-Introduction.md
@@ -11,7 +11,7 @@
 
 ### Who can use Wasabi?
 
-Every single line of code in Wasabi, the [wallet](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Fluent.Desktop), the [backend server](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend), the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Daemon), the [tests](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Tests), the [packager](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Packager), the [library](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi), the [api](https://wasabiwallet.io/swagger/), the [documentation](https://github.com/zkSNACKs/WasabiDoc) - has always been and will always be libre and open-source under the [MIT license](https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md).
+Every single line of code in Wasabi, the [wallet](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Fluent.Desktop), the [backend server](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Backend), the [daemon](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Daemon), the [tests](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Tests), the [packager](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Packager), the [library](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi), the [api](https://wasabiwallet.io/swagger/), the [documentation](https://github.com/WalletWasabi/WasabiDoc) - has always been and will always be libre and open-source under the [MIT license](https://github.com/WalletWasabi/WalletWasabi/blob/master/LICENSE.md).
 This means that anyone, yes, ANYONE can use Wasabi without permission, for any use case, free of charge.
 
 Wasabi is used by individuals to make everyday payments, to manage their hardware wallet long term hodlings, and to CoinJoin their sats for added privacy.
@@ -78,13 +78,13 @@ Yes, you can check the status of Wasabi-related services and websites (like APIs
 ### What software supplies the block filters that Wasabi uses?
 
 The zkSNACKs coordinator supplies identical filters to every client.
-This means that you rely on the [Wasabi backend](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend) to provide valid filters.
+This means that you rely on the [Wasabi backend](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Backend) to provide valid filters.
 But because you download the blocks from a random Bitcoin peer-to-peer node - or your own node - the coordinator cannot spy on which blocks you are interested in.
 Furthermore, the random node will only know which block is needed but it won't have any clue which transaction(s) belongs to the wallet.
 
 ### Is the Backend's (Coordinator) code open-source?
 
-Yes, you can verify the code on [GitHub](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Backend).
+Yes, you can verify the code on [GitHub](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Backend).
 
 ### Is there an Android/iOs version?
 
@@ -115,7 +115,7 @@ This gives a false sense of security, **but does not worsen the existing privacy
 It would also be noticeable to all users excluding the user being targeted as their coins would not be mixed.
 It has been argued that this 'attack' would be very costly in terms of fees because the number of coins being mixed is verifiable.
 Though it is true that remixes pay zero coordination fee to zkSNACKs, they do pay mining fees.
-See [here](https://github.com/zkSNACKs/WabiSabi/blob/master/protocol.md#attacks-on-privacy) for more info.
+See [here](https://github.com/WalletWasabi/WabiSabi/blob/master/protocol.md#attacks-on-privacy) for more info.
 
 ### What is the history of Wasabi?
 
@@ -134,7 +134,7 @@ Key dates:
 
 ### Why is Wasabi libre and open-source software?
 
-Wasabi follows Bitcoin's philosophy by making the software [open-source](https://github.com/zkSNACKs/WalletWasabi/) and by publishing it under [MIT license](https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md).
+Wasabi follows Bitcoin's philosophy by making the software [open-source](https://github.com/WalletWasabi/WalletWasabi/) and by publishing it under [MIT license](https://github.com/WalletWasabi/WalletWasabi/blob/master/LICENSE.md).
 Bitcoin users prefer open-source software to proprietary software for a number of reasons, including:
 
 :::tip Control
@@ -195,12 +195,12 @@ For more info please see [WabiSabi](https://github.com/zksnacks/wabisabi).
 ### What are the supported operating systems?
 
 Wasabi runs in most operating systems with 64-bit architecture.
-For the complete list of all the officially supported operating systems, click [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems).
+For the complete list of all the officially supported operating systems, click [here](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems).
 
 ### What are the minimal requirements to run Wasabi?
 
-As long as your operating system is [supported](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems), Wasabi should be able to run on your hardware.
+As long as your operating system is [supported](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-operating-systems), Wasabi should be able to run on your hardware.
 The more transactions a wallet has made, the more resources Wasabi will consume, particularly RAM.
 The software can also consume a significant amount of CPU for specific tasks, such as coinjoins or wallet loading.
 Approximately 3 GB of disk space are also needed, mainly to store the [block filters](/FAQ/FAQ-UseWasabi.md#what-are-bip-158-block-filters).
-If you are running the wallet on a system with scarce resources, consider using the [daemon](https://github.com/zkSNACKs/WalletWasabi/tree/master/WalletWasabi.Daemon) instead of the GUI application.
+If you are running the wallet on a system with scarce resources, consider using the [daemon](https://github.com/WalletWasabi/WalletWasabi/tree/master/WalletWasabi.Daemon) instead of the GUI application.

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -158,7 +158,7 @@ Moreover, our trustless software architecture prevents us from gathering this in
 - A transaction fee is only charged by the service provider for CoinJoin transactions.
 - We only provide written support, and NEVER ask for recovery words, passphrases or similar security critical information.
 
-Read the whole document of [terms and conditions, privacy policy, and legal statement here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Legal/Assets/LegalDocumentsWw2.txt)
+Read the whole document of [terms and conditions, privacy policy, and legal statement here](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi/Legal/Assets/LegalDocumentsWw2.txt)
 
 ### Can I import a watch-only extended public key?
 
@@ -672,7 +672,7 @@ This is good for privacy, and also saves you some transaction fees.
 
 ### How can I bump the transaction fee with child pays for parent (CPFP)?
 
-Since Wasabi version [2.0.4](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.4) this FAQ is now obsolete because of the new [_Speed Up Transaction_ feature](/FAQ/FAQ-UseWasabi.md#how-can-i-speed-up-a-pending-transaction) that can be used.
+Since Wasabi version [2.0.4](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.4) this FAQ is now obsolete because of the new [_Speed Up Transaction_ feature](/FAQ/FAQ-UseWasabi.md#how-can-i-speed-up-a-pending-transaction) that can be used.
 
 ### How can I speed up a pending/unconfirmed transaction (CPFP/RBF)?
 
@@ -749,7 +749,7 @@ So when sending, less than 0.00338462 BTC (to cover the mining fees) should be e
 ![Wasabi Wallet Privacy Progress Tile](/PrivacyProgressTile.png "Wasabi Wallet Privacy Progress Tile")
 
 :::tip Use the Privacy Suggestions
-Since Wasabi version [2.0.4](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.4), there are privacy suggestions to only send private or semi-private coins.
+Since Wasabi version [2.0.4](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.4), there are privacy suggestions to only send private or semi-private coins.
 :::
 
 Read more [here](/using-wasabi/Send.md#privacy-suggestions).
@@ -1171,7 +1171,7 @@ Type in your recovery words in the correct order, click on `Verify` and it will 
 ### What hardware wallets does Wasabi support?
 
 Wasabi uses the Bitcoin Core [Hardware Wallet Interface (HWI)](https://github.com/bitcoin-core/HWI) which allows it to support a variety of hardware wallets.
-For the complete list of all the officially supported hardware wallets, click [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets).
+For the complete list of all the officially supported hardware wallets, click [here](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets).
 
 ### Why does Wasabi use the Hardware Wallet Interface?
 
@@ -1291,12 +1291,12 @@ You should put a meaningful label when you generate a receive address in your ha
 ### Can I use Trezor One with Wasabi?
 
 No. Unfortunately, Trezor One is not supported by Wasabi Wallet.
-For the complete list of all the officially supported hardware wallets, click [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets).
+For the complete list of all the officially supported hardware wallets, click [here](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets).
 
 ### Can I use BitBox with Wasabi?
 
 No. Unfortunately, BitBox is not supported by Wasabi Wallet.
-For the complete list of all the officially supported hardware wallets, click [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets).
+For the complete list of all the officially supported hardware wallets, click [here](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets).
 
 ### How can I type in the passphrase of my Trezor T?
 
@@ -1592,7 +1592,7 @@ For (legal) information and questions, please refer to the [Shopinbit website](h
 ### Can I change the default ports for the Wasabi's bundled Tor?
 
 Yes. 
-Since Wasabi version [2.0.6](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.6) it is possible to specify the Tor SOCKS5 and the Tor control ports.
+Since Wasabi version [2.0.6](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.6) it is possible to specify the Tor SOCKS5 and the Tor control ports.
 This can be done by specifying the port(s) at startup with the [startup parameters](/using-wasabi/StartupParameters.md#non-config-file-configurations).
 
 ### Where does the BTC exchange rate come from?

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ features:
 
 This is [Wasabi Wallet's](https://wasabiwallet.io) open source documentation.
 Here you will find information about the nuances of privacy in Bitcoin, how Wasabi solves some of the existing problems, and how you can use this tool to defend yourself.
-Everyone is welcome to make the Wasabi Wallet documentation better, by contributing [on GitHub](https://github.com/zkSNACKs/WasabiDoc/)!
+Everyone is welcome to make the Wasabi Wallet documentation better, by contributing [on GitHub](https://github.com/WalletWasabi/WasabiDoc/)!
 The documentation of Wasabi Wallet 1.0 is archived [here](https://web.archive.org/web/20220804041943/https://docs.wasabiwallet.io/).
 
 ## How to use this documentation

--- a/docs/building-wasabi/ContributionChecklist.md
+++ b/docs/building-wasabi/ContributionChecklist.md
@@ -31,7 +31,7 @@ All such contributions are very welcomed and greatly appreciated.
 
 ## Say hello and get started
 
-- Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg) and especially check out our [GitHub repository](https://github.com/zkSnacks/WalletWasabi).
+- Join our [Slack](https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg) and especially check out our [GitHub repository](https://github.com/WalletWasabi/WalletWasabi).
 - Introduce yourself, say a bit about your skills and interests.
 This will help others point you in the right direction.
 - Explore the communication channels and find out what the peers are tinkering on, learn about the project and who is contributing in what way.
@@ -77,9 +77,9 @@ In case you have been contributing already, feel free to let other Wasabikas kno
 ### GitHub Contributor
 
 1. **Find a problem somewhere in Wasabi-land** that (a) needs fixing or improvement and (b) is a match for your skills and interests.
-Browse [open issues](https://github.com/zksnacks/walletwasabi/issues) and ask around about what other contributors think needs fixing.
+Browse [open issues](https://github.com/WalletWasabi/walletwasabi/issues) and ask around about what other contributors think needs fixing.
 Because while you don’t need anybody’s permission and you can work on whatever you want, you’ll want to know up front whether anybody else is going to care about the work you do.
-2. **Do work to fix that problem.** Submit your fix for review with a pull request (for [code](https://github.com/zkSNACKs/WalletWasabi/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) and [documentation](https://github.com/zkSNACKs/WasabiDoc/pulls) changes) or with a GitHub [issue](https://github.com/zksnacks/walletwasabi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) (for everything else).
+2. **Do work to fix that problem.** Submit your fix for review with a pull request (for [code](https://github.com/WalletWasabi/WalletWasabi/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) and [documentation](https://github.com/WalletWasabi/WasabiDoc/pulls) changes) or with a GitHub [issue](https://github.com/WalletWasabi/walletwasabi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) (for everything else).
 3. **Request that others review your work.** The best way to do this is by writing good commit comments and pull request/issue descriptions that clearly explain the problem your work is intended to solve, why it’s important, and why you fixed it the way you did.
 Make it as easy as possible for others to review your work. Make it a *pleasure* for others to review your work.
 4. **Incorporate review feedback** you get until your fix gets merged or is otherwise accepted.

--- a/docs/building-wasabi/LICENSE.md
+++ b/docs/building-wasabi/LICENSE.md
@@ -20,4 +20,4 @@ Licensed works, modifications, and larger works may be distributed under differe
 | Private use    |              |                              |
 
 
-You can check the license [here](https://github.com/zkSNACKs/WasabiDoc/blob/master/LICENSE).
+You can check the license [here](https://github.com/WalletWasabi/WasabiDoc/blob/master/LICENSE).

--- a/docs/building-wasabi/Security.md
+++ b/docs/building-wasabi/Security.md
@@ -7,10 +7,10 @@
 
 # Security Policy
 
-If a vulnerability does not compromise users' privacy or security, open a [regular GitHub issue](https://github.com/zkSNACKs/WalletWasabi/issues/new/choose).
+If a vulnerability does not compromise users' privacy or security, open a [regular GitHub issue](https://github.com/WalletWasabi/WalletWasabi/issues/new/choose).
 
 If it does, then pay great care to responsible disclosure.
-Report a [private vulnerability on GitHub](https://github.com/zkSNACKs/WalletWasabi/security/advisories/new) or send an email to molnardavid84@gmail.com, preferably using PGP encryption: `F079 0C08 68BD BAB8 EE33 F9CE 50FB 7FEB 00F9 7588`
+Report a [private vulnerability on GitHub](https://github.com/WalletWasabi/WalletWasabi/security/advisories/new) or send an email to molnardavid84@gmail.com, preferably using PGP encryption: `F079 0C08 68BD BAB8 EE33 F9CE 50FB 7FEB 00F9 7588`
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/docs/glossary/Glossary-PrivacyWasabi.md
+++ b/docs/glossary/Glossary-PrivacyWasabi.md
@@ -172,7 +172,7 @@ Read more: [RPC Interface](/using-wasabi/RPC.md)
 
 Safety coinjoin is a concept for doing an extra coinjoin after a user registers only _anonymity score_ 1 (non-private) coins in their first round.
 
-This was added in Wasabi [2.0.6 version](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.6) to increase privacy for people who generate a new wallet -> receive a coin -> do one coinjoin -> send all the money out.
+This was added in Wasabi [2.0.6 version](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.6) to increase privacy for people who generate a new wallet -> receive a coin -> do one coinjoin -> send all the money out.
 It aims to prevent targeted analysis that compares the value of consolidated coinjoin outputs with the value of one of the coinjoin's inputs.
 
 ### Taint

--- a/docs/using-wasabi/BuildSource.md
+++ b/docs/using-wasabi/BuildSource.md
@@ -34,7 +34,7 @@ Be aware that these branches might be unstable and can include bugs that lead to
 Clone Wasabi repository:
 
 ```sh
-git clone https://github.com/zkSNACKs/WalletWasabi.git
+git clone https://github.com/WalletWasabi/WalletWasabi.git
 cd WalletWasabi/WalletWasabi.Fluent.Desktop
 ```
 

--- a/docs/using-wasabi/CoinJoin.md
+++ b/docs/using-wasabi/CoinJoin.md
@@ -143,7 +143,7 @@ The output registration phase ends when the value of cleartext outputs is equal 
 If after a timeout not all outputs are registered, then this round is abandoned, the missing inputs are temporarily banned, and a new round is started.
 
 :::tip Possibility of Taproot outputs from coinjoin
-Since Wasabi [version 2.0.3](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.3) coinjoin outputs can be SegWit v0 and SegWit v1 (Taproot).
+Since Wasabi [version 2.0.3](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.3) coinjoin outputs can be SegWit v0 and SegWit v1 (Taproot).
 If running this version or higher, the client registers the output type in a semi-random way (~50% chance of receiving Taproot output).
 :::
 

--- a/docs/using-wasabi/Daemon.md
+++ b/docs/using-wasabi/Daemon.md
@@ -16,7 +16,7 @@ There is also a headless daemon where you do not run a resource-intensive GUI, b
 Running the daemon minimizes the usage of resources (CPU, GPU, Memory, Bandwidth) with the goal of making it more suitable for running all the time in the background.
 The [RPC interface](/using-wasabi/RPC.md) can be used to interact with the Daemon.
 
-The daemon is included in the package starting from Wasabi version [2.0.4](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.4) and can be launched using the command line.
+The daemon is included in the package starting from Wasabi version [2.0.4](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.4) and can be launched using the command line.
 
 The desktop app (GUI) is built on top of the daemon.
 Meaning that command line arguments/variables can also be used to configure the desktop app.

--- a/docs/using-wasabi/DeterministicBuild.md
+++ b/docs/using-wasabi/DeterministicBuild.md
@@ -7,4 +7,4 @@
 
 # Deterministic Build
 
-The guide for the deterministic builds can be found in the [WalletWasabi repository](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md).
+The guide for the deterministic builds can be found in the [WalletWasabi repository](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md).

--- a/docs/using-wasabi/DiscreetMode.md
+++ b/docs/using-wasabi/DiscreetMode.md
@@ -27,4 +27,4 @@ You can activate or deactivate by clicking the Discreet Mode icon in the bottom 
 - Discreet Mode only masks the surface.
 This means that when you click to see more Details, some information (which wasn't visible at first) will be shown.
 - When hovering over the ### chars with the cursor, the content will be visible for a short amount of time.
-- Some justification of design decisions can be seen [here](https://github.com/zkSNACKs/WalletWasabi/issues/2234).
+- Some justification of design decisions can be seen [here](https://github.com/WalletWasabi/WalletWasabi/issues/2234).

--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -20,9 +20,9 @@ Download the packages either from the official [WasabiWallet.io](https://wasabiw
 
 ![Operating systems supported by Wasabi Wallet](/DownloadAll.png "Operating systems supported by Wasabi Wallet")
 
-Although there is automatic signature verification on Windows and macOS, it is still recommended to manually **VERIFY PGP SIGNATURES** of the downloaded package with zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) before installing Wasabi.
+Although there is automatic signature verification on Windows and macOS, it is still recommended to manually **VERIFY PGP SIGNATURES** of the downloaded package with zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt) before installing Wasabi.
 This protects you against malicious phishing sites giving you back-doored wallet software.
-If you have personally verified zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) and you are familiar with the [Web Of Trust](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature), please consider also [signing it](https://www.gnupg.org/gph/en/manual/x334.html).
+If you have personally verified zkSNACKs' PGP public key [${zksnacksPublicKeyFingerprint}](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt) and you are familiar with the [Web Of Trust](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature), please consider also [signing it](https://www.gnupg.org/gph/en/manual/x334.html).
 
 :::tip Always
 Don't trust - Verify!
@@ -58,7 +58,7 @@ Among others, here is where your wallet files and your logs reside.
 
 If you have already imported zkSNACKs' PGP public key, then jump to step 2.
 
-1. Download zkSNACKs' PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`.
+1. Download zkSNACKs' PGP public key [here](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`.
 
 	Verify that the fingerprint is `${zksnacksPublicKeyFingerprint}` by running this command `gpg --list-keys zkSNACKs`.
 
@@ -84,7 +84,7 @@ Among others, here is where your wallet files and your logs reside.
 
 If you have already imported zkSNACKs' PGP public key, then jump to step 2.
 
-1. Download zkSNACKs' PGP public key [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`.
+1. Download zkSNACKs' PGP public key [here](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt), and then import it with `gpg --import PGP.txt`.
 
 	Verify that the fingerprint is `${zksnacksPublicKeyFingerprint}` by running this command `gpg --list-keys zkSNACKs`.
 
@@ -132,7 +132,7 @@ If you have already imported zkSNACKs' PGP public key, then jump to step 4.
 
 1. [Get GnuPG](https://www.gnupg.org/download/index.html).
 
-2. Copy [zkSNACKs' PGP public key](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt) into a new `TextEdit` document and saving it as `zkSNACKsPubKey.txt`.
+2. Copy [zkSNACKs' PGP public key](https://github.com/WalletWasabi/WalletWasabi/blob/master/PGP.txt) into a new `TextEdit` document and saving it as `zkSNACKsPubKey.txt`.
 Before saving, you need to go to `Format / Make Plain Text` (otherwise TextEdit will not be able to save it as a .txt file).
 
 3. Open Terminal and go to the folder in which you saved the `zkSNACKsPubKey.txt` file and import the PGP public key with `sudo gpg --import zkSNACKsPubKey.txt`.

--- a/docs/using-wasabi/RPC.md
+++ b/docs/using-wasabi/RPC.md
@@ -18,7 +18,7 @@ The RPC server does NOT support batch requests or TLS communications (because it
 Requests are served in order one-by-one in series (no parallel processing).
 It is intentionally limited to serve only one whitelisted local address and it is disabled by default.
 
-The more user friendly command line interface `wcli` can be found [here](https://github.com/zkSNACKs/WalletWasabi/tree/master/Contrib/CLI).
+The more user friendly command line interface `wcli` can be found [here](https://github.com/WalletWasabi/WalletWasabi/tree/master/Contrib/CLI).
 
 ## Configure RPC
 
@@ -979,7 +979,7 @@ curl -s --data-binary '{"jsonrpc":"2.0", "method": "getnewaddress", "params": { 
 
 ## Expose the RPC server as an onion service
 
-Since Wasabi version [2.0.6](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.6) the RPC can be exposed as an onion service, which enables remote control.
+Since Wasabi version [2.0.6](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.6) the RPC can be exposed as an onion service, which enables remote control.
 
 The RPC server can be exposed as an onion service by using the _rpconionenabled=true_ [start up parameter](/using-wasabi/StartupParameters.md) or the environment variable.
 

--- a/docs/using-wasabi/Send.md
+++ b/docs/using-wasabi/Send.md
@@ -148,7 +148,7 @@ For a deeper dive into the fee estimation process, [this article](https://bitcoi
 
 ## Privacy Suggestions
 
-Since Wasabi version [2.0.4](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.4) the _Preview Transaction_ dialog contains privacy suggestions.
+Since Wasabi version [2.0.4](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.4) the _Preview Transaction_ dialog contains privacy suggestions.
 The privacy suggestions help the user to improve their transaction.
 They are displayed when hovering over the triangle or shield in the top right corner.
 The suggestions are based on the current coin selection for this transaction.
@@ -198,7 +198,7 @@ This can be used to speed up or cancel a transaction.
 The miners are incentivized to mine the transaction with the higher fee rate, as this will earn them more money.
 If the new higher fee rate paying transaction is confirmed, the old transaction can be considered "replaced".
 
-Since Wasabi version [2.0.4](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.4) it is possible to easily speed up or cancel a pending transaction.
+Since Wasabi version [2.0.4](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.4) it is possible to easily speed up or cancel a pending transaction.
 Speeding up and cancelling are similar to each other, the main difference being that a _Cancel Transaction_ will send the coins to a new address owned by the user/wallet (this is all done automatically).
 The transaction is then "cancelled" because the bitcoin (minus the fees) is returned to the user's wallet.
 

--- a/docs/using-wasabi/WalletLoad.md
+++ b/docs/using-wasabi/WalletLoad.md
@@ -47,7 +47,7 @@ In this step, your Wasabi behaves like any other full node, and cannot be differ
 
 ### TurboSync
 
-Since Wasabi version [2.0.4](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.4) a new feature is added called _TurboSync_.
+Since Wasabi version [2.0.4](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.4) a new feature is added called _TurboSync_.
 _TurboSync_ leads to a significant reduction of wallet loading time, especially for a big wallet.
 
 During a coinjoin, a new address (key) has to be generated for each output.

--- a/docs/using-wasabi/WasabiSetupVM.md
+++ b/docs/using-wasabi/WasabiSetupVM.md
@@ -109,7 +109,7 @@ Start the gnome-terminal of `source-wasabi`.
 Clone & run Wasabi.
 
 ```sh
-[user@source-wasabi ~]$ git clone https://github.com/zkSNACKs/WalletWasabi.git
+[user@source-wasabi ~]$ git clone https://github.com/WalletWasabi/WalletWasabi.git
 [user@source-wasabi ~]$ cd WalletWasabi/WalletWasabi.Fluent.Desktop
 [user@source-wasabi ~]$ dotnet run
 ```
@@ -234,7 +234,7 @@ Start your cloned VM, and open a terminal window.
 Clone & run Wasabi.
 
 ```sh
-your@vm:~$ git clone https://github.com/zkSNACKs/WalletWasabi.git
+your@vm:~$ git clone https://github.com/WalletWasabi/WalletWasabi.git
 your@vm:~$ cd WalletWasabi/WalletWasabi.Fluent.Desktop
 your@vm:~$ dotnet run
 ```

--- a/docs/why-wasabi/TransactionGraph.md
+++ b/docs/why-wasabi/TransactionGraph.md
@@ -22,7 +22,7 @@ And the sender can see the future spending of the receiver.
 
 ### WabiSabi coinjoins
 
-In order to obfuscate the link between inputs and outputs, Wasabi uses the [WabiSabi](https://github.com/zkSNACKs/WabiSabi) coinjoin protocol.
+In order to obfuscate the link between inputs and outputs, Wasabi uses the [WabiSabi](https://github.com/WalletWasabi/WabiSabi) coinjoin protocol.
 The Wasabi central coordinator cannot steal and cannot spy, it simply helps many peers to build a huge transaction, with many inputs, and many outputs.
 The non-private inputs can be linked to their previous transaction history.
 However, the coinjoin outputs with an anonymity score cannot be tied to the inputs.


### PR DESCRIPTION
there are two remaining links to zksnacks GH at `building-wasabi/contribution checklist` and the build status in the README

> You can find the schedule, call link, past recordings and more at the [Wasabi Research Club repository](https://github.com/zkSNACKs/WasabiResearchClub/).

kept it as the links still work and changing it to WalletWasabi will break it