### PR TITLE
FAQ: How do I find a coordinator?

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1067,6 +1067,21 @@ You can send banned coins to anyone you want.
 This is a temporary ban on your coins in participation of the CoinJoin.
 :::
 
+### How do I find a coordinator?
+
+There are several ways to find a coordinator:
+
+- Users can do their own discovery with tools like [Wasabi Nostr](https://github.com/Kukks/wasabinostr), which discovers Wasabi coordinators over Nostr.
+- Public announcement websites, such as [Wasabist](https://wasabist.io), [Wabisator](https://wabisator.com), [Liquisabi bot (Twitter)](https://x.com/liquisabi) and [Liquisabi bot (Nostr)](https://njump.me/npub1u4rl3zlfa2efxslhypf4v6r8va5e0c9smxyr5676pxkyk0chn33s0teswa).
+- A coordinator can advertise themselves, like on social media.
+
+:::warning Don't trust, verify
+The listed public announcement websites are community run projects, use them with caution.
+It is best to do the discovery yourself.
+:::
+
+> It's on the roadmap to have the discovery built into Wasabi, so users don't have to do it manually.
+
 ### How do I change the coordinator?
 
 Since Wasabi version [2.0.8](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.8), the coordinator can be changed in the GUI in the _Coordinator_ tab in the settings.


### PR DESCRIPTION
I think it's ok to list wasabist and wabisator, they have been around for a bit of time now and are useful for a lot of people.
And they are used/linked with support requests.
But still put the warning there in case they would do something malicious, and that it is not an endorsement to use them.