### PR TITLE
update what is the maximum coinjoin amount

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -777,8 +777,9 @@ The minimum amount for the current coinjoin round(s) is displayed on the https:/
 
 ### What is the maximum amount I can coinjoin?
 
-The maximum possible amount is 43000 BTC per coin per coinjoin round.
-If the user has a coin of more than 43000 BTC, then it must be broken down into smaller parts to be able to coinjoin.
+The coordinator sets the maximum amount of bitcoin an input can have to participate in a coinjoin round.
+
+The default maximum is a 43000 BTC UTXO.
 
 ### What are the fees for the coinjoin?
 


### PR DESCRIPTION
update it 
and remove 
> If the user has a coin of more than 43000 BTC, then it must be broken down into smaller parts to be able to coinjoin.

it's noise as it was more a bit of a funny comment
max amounts are big enough, users will not have to break down their coins

or can come up with that themselves
