### PR TITLE
update bitbox supported FAQ

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1284,8 +1284,9 @@ For the complete list of all the officially supported hardware wallets, click [h
 
 ### Can I use BitBox with Wasabi?
 
-No. Unfortunately, BitBox is not supported by Wasabi Wallet.
-For the complete list of all the officially supported hardware wallets, click [here](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets).
+Yes, since Wasabi version [2.0.7](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.7) BitBox is supported.
+
+The device by default asks for a "Pairing code", currently, there is no such function in Wasabi. Therefore, either disable the feature or unlock the device with BitBoxApp or hwi-qt before using it with Wasabi.
 
 ### How can I type in the passphrase of my Trezor T?
 

--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1284,7 +1284,7 @@ For the complete list of all the officially supported hardware wallets, click [h
 
 ### Can I use BitBox with Wasabi?
 
-Yes, since Wasabi version [2.0.7](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.7) BitBox is supported.
+Yes, since Wasabi version [2.0.7](https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.0.7) BitBox02-BtcOnly is supported.
 
 The device by default asks for a "Pairing code", currently, there is no such function in Wasabi. Therefore, either disable the feature or unlock the device with BitBoxApp or hwi-qt before using it with Wasabi.
 


### PR DESCRIPTION
update it

I have no experience with it myself. So I'm copy pasting the info listed here https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets about the _pairing code_, assuming it is correct