### PR TITLE
coinjoin: mention coordinator needs to be configured

### DIFF
--- a/docs/using-wasabi/CoinJoin.md
+++ b/docs/using-wasabi/CoinJoin.md
@@ -26,6 +26,8 @@ WabiSabi enables centrally coordinated coinjoins with variable amounts in a trus
 2. Wait. Wasabi coinjoins automatically in the background.
 3. You're done! You can make private payments now.
 
+> A coordinator needs to be [configured](https://docs.wasabiwallet.io/FAQ/FAQ-UseWasabi.html#how-do-i-change-the-coordinator).
+
 ### Music box
 
 After opening a hot wallet, it will automatically start a countdown to start coinjoining (±10 minutes).


### PR DESCRIPTION
there is no mention of this in the coinjoin page, so add it. 
Because if you read this page, it doesn't work "automatically".
And link to the FAQ about how to configure.

![image](https://github.com/user-attachments/assets/f0d82fad-7d07-4d59-a6b3-f2c3ca61e494)
