### PR TITLE
FAQ: CJ on hww: remove old trezor suite cj link

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1250,11 +1250,6 @@ Thus currently you have to send the bitcoins from your hardware wallet to a `hot
 
 Read more [here](/using-wasabi/ColdWasabi.md#cold-wasabi-protocol).
 
-:::tip
-Trezor now supports coinjoin with the Trezor Suite, using same rounds as Wasabi Wallet users.
-Read more [here](https://content.trezor.io/coinjoin).
-:::
-
 ### Does Ledger Live send my public keys and addresses to a third party server?
 
 Only if you add your accounts in the app, but not if you update your device firmware or install apps.


### PR DESCRIPTION
this link doesn't work anymore and there is no way for users to coinjoin using suite with only using the UI.
(need to start trezor suite with the right params)

so remove this

and this was more something worth mentioning in zkSNACKs era