### PR TITLE
Small clarification

### DIFF
--- a/docs/using-wasabi/CoinJoin.md
+++ b/docs/using-wasabi/CoinJoin.md
@@ -26,7 +26,7 @@ WabiSabi enables centrally coordinated coinjoins with variable amounts in a trus
 2. Wait. Wasabi coinjoins automatically in the background.
 3. You're done! You can make private payments now.
 
-> A coordinator needs to be [configured](https://docs.wasabiwallet.io/FAQ/FAQ-UseWasabi.html#how-do-i-change-the-coordinator).
+> A coordinator must be [configured](https://docs.wasabiwallet.io/FAQ/FAQ-UseWasabi.html#how-do-i-change-the-coordinator) before using coinjoin for the first time.
 
 ### Music box
 


### PR DESCRIPTION
Clarify that the coordinator should be configured only for the first time to use coinjoin. 