### PR TITLE
clarify how coinjoin to other wallet feature works

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -965,6 +965,11 @@ Go to the _Wallet Settings_ -> _Coinjoin_ tab -> select the wallet you want to c
 
 ![Coinjoin To Wallet](/WalletSettingsCoinjoinToWallet.png "Coinjoin To Wallet")
 
+:::warning
+This feature does **not** take into account the anonymity score of coins.
+It will always send all coinjoin outputs to the other wallet, regardless of whether they are (sufficiently) private or not.
+:::
+
 ### How long does it take to make my wallet 100% private?
 
 Depending on many factors, such as the `Anonymity score target`, the `Coinjoin strategy`, the amount of bitcoin, and the liquidity of the coordinator, this can take from a few hours to several days or even more.


### PR DESCRIPTION
clarify it and add it as a warning, as it seems to be causing people to think that it will coinjoin coins to the other wallet once AS target is reached, which it doesn't

![image](https://github.com/user-attachments/assets/9bd3254c-45dd-42e7-b225-f0ec9b3e6ee9)
