### PR TITLE
Change Liquisabi's nostr link

### DIFF
--- a/docs/FAQ/FAQ-UseWasabi.md
+++ b/docs/FAQ/FAQ-UseWasabi.md
@@ -1062,7 +1062,7 @@ This is a temporary ban on your coins in participation of the CoinJoin.
 There are several ways to find a coordinator:
 
 - Users can do their own discovery with tools like [Wasabi Nostr](https://github.com/Kukks/wasabinostr), which discovers Wabisabi coordinators over Nostr.
-- Public announcement websites, such as [Wasabist](https://wasabist.io), [Wabisator](https://wabisator.com), [Liquisabi bot (X)](https://x.com/liquisabi) and [Liquisabi bot (Nostr)](https://njump.me/npub1u4rl3zlfa2efxslhypf4v6r8va5e0c9smxyr5676pxkyk0chn33s0teswa).
+- Public announcement websites, such as [Wasabist](https://wasabist.io), [Wabisator](https://wabisator.com), [Liquisabi bot (X)](https://x.com/liquisabi) and [Liquisabi bot (Nostr)](https://primal.net/p/npub1u4rl3zlfa2efxslhypf4v6r8va5e0c9smxyr5676pxkyk0chn33s0teswa).
 - A coordinator can advertise themselves, like on social media.
 - Run coordinators in your social circles
 


### PR DESCRIPTION
The njump link for Liquisabi only shows few posts. Replace it with the primal link. 