### PR TITLE
add trailing zero to version number

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -17,7 +17,7 @@ export default defineUserConfig({
         const render = md.renderer.render;
 
         const variables = {
-            currentVersion: '2.2.1',
+            currentVersion: '2.2.1.0',
             dotnetVersion: '8.0',
             zksnacksPublicKeyFingerprint: '6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E'
         }


### PR DESCRIPTION
2.2.1 -> 2.2.1.0

current one results in incorrect package names and thus invalid commands

![image](https://github.com/user-attachments/assets/37e626dc-a5d3-4bf9-b787-09ed7bbec891)

while the user needs to run `Wasabi-2.2.1.0-linux-x64.tar.gz`

