### PR TITLE
RPC payincoinjoin: clarify coinjoin coin selector is unaware of scheduled payment

### DIFF
--- a/docs/using-wasabi/RPC.md
+++ b/docs/using-wasabi/RPC.md
@@ -811,9 +811,11 @@ A _payincoinjoin_ is written to the logs and its status can be seen by using the
 Payments in coinjoin can theoretically be made to any ScriptPubKey. 
 However, the coordinator may only accept certain types of outputs.
 
-Currently the default maximum is 4 payments per client per coinjoin.
+The default maximum is 4 payments per client per coinjoin.
 
 _payincoinjoin_ only registers a payment, so if coinjoin is not running or the amount is lower than the wallet balance, the payment is queued.
+Currently the coinjoin coin selector does not take into account that a payment is registerd.
+Therefore, it is possible that the payment will not be executed due to insufficient and/or non-optimal coins being selected, even though there are sufficient funds available.
 
 Pending payments can be removed by using the _cancelpaymentincoinjoin_ method.
 Pending payments are also removed if the Wasabi client restarts.


### PR DESCRIPTION
When you schedule a payment you expect the payment to be executed when you have enough funds.

This is not the case, it can happen that it selected too few coins or too small amount ones and thus the payment is not executed.

So clarify it in the doc.