### PR TITLE
getting started: link to how to find coord FAQ

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -70,6 +70,8 @@ Click on `Receive` at the top right to [receive](/using-wasabi/Receive.md) some 
 A coordinator needs to be configured to participate in coinjoin(s).
 This can be done at the _Coordinator_ tab in the _Settings_, along with other coordinator settings.
 
+Read more [here](/FAQ/FAQ-UseWasabi.html#how-do-i-find-a-coordinator) about how to find a coordinator.
+
 ![Music Box Coordinator Not Configured](/MusicBoxCoordinatorNotConfigured.png "Music Box Coordinator Not Configured")
 
 It is also possible to use a _coordinator connection string_ which Wasabi automatically detects in the clipboard and it will apply these settings with a dialog for the user to confirm.


### PR DESCRIPTION
I did not read correctly Turbo his suggestion https://github.com/WalletWasabi/WasabiDoc/pull/1876#issuecomment-2599217132.
I read "link to the _how to change coordinator_ FAQ".

linking to how to find coordinator FAQ should be done indeed
my bad

---

![Screenshot from 2025-01-18 13-15-43](https://github.com/user-attachments/assets/c057bbe9-0b51-4e07-8893-ede051bbbdce)
