### PR TITLE
BIP: add SLIP39 support

### DIFF
--- a/docs/using-wasabi/BIPs.md
+++ b/docs/using-wasabi/BIPs.md
@@ -37,3 +37,9 @@ Here is a list of all the supported and integrated Bitcoin Improvement Proposals
 
 - [BIP 37: Bloom filters](https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki)
 - [BIP 69: Lexicographical Indexing of Transaction Inputs and Outputs](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki)
+
+# Supported SLIPs
+
+Wasabi supports one Satoshi Labs Improvement Proposal:
+
+- [SLIP 39: Shamir's Secret-Sharing for Mnemonic Codes](https://github.com/satoshilabs/slips/blob/master/slip-0039.md)


### PR DESCRIPTION
just adding it at the BIPs page seems the best option.

closes https://github.com/WalletWasabi/WasabiDoc/issues/1931