### PR TITLE
Change coins: add change address type can be set

### DIFF
--- a/docs/using-wasabi/ChangeCoins.md
+++ b/docs/using-wasabi/ChangeCoins.md
@@ -25,6 +25,9 @@ As a result, when you send this leftover/change coin in a new transaction, it is
 
 This process is applicable to any Bitcoin transaction where the _sent_ amount is less than the total value of the input UTXO.
 
+> By default, the change address type is random between SegWit & Taproot. 
+This can be set to SegWit or Taproot only in the _Wallet Settings_.
+
 ### Coinjoin change
 
 In some few cases, especially for the wealthiest user of a coinjoin, there will be an `anonymity score 1` output in a coinjoin transaction.


### PR DESCRIPTION
closes https://github.com/WalletWasabi/WasabiDoc/issues/1894

adds a small note, so it is mentioned somewhere in the docs
![Screenshot from 2025-06-11 14-53-27](https://github.com/user-attachments/assets/ea0e5d4c-bb9f-45b6-a4e2-4000d66c2bb8)
