### PR TITLE
receive: add info about unconfirmed tx's

### DIFF
--- a/docs/using-wasabi/Receive.md
+++ b/docs/using-wasabi/Receive.md
@@ -116,7 +116,7 @@ Now, look how this will be displayed if I use the two coins with bad labels: `Ma
 So, think about coins, think about who knows and make sure to make decisions about privacy based on what you are going to reveal and to whom.
 Wasabi doesn't care about why you transact with bitcoins, it only cares about who you transact with because this is what helps you reclaim your privacy.
 
-## Unconfirmed transactions
+## Unconfirmed transaction
 
 Wasabi will be aware of an incoming unconfirmed transaction if it is broadcasted across the P2P network while Wasabi is online. If the transaction was broadcasted while Wasabi was offline, it will only show up after receiving its first confirmation.
 

--- a/docs/using-wasabi/Receive.md
+++ b/docs/using-wasabi/Receive.md
@@ -115,3 +115,7 @@ Now, look how this will be displayed if I use the two coins with bad labels: `Ma
 
 So, think about coins, think about who knows and make sure to make decisions about privacy based on what you are going to reveal and to whom.
 Wasabi doesn't care about why you transact with bitcoins, it only cares about who you transact with because this is what helps you reclaim your privacy.
+
+## Unconfirmed transactions
+
+Wasabi will be aware of incoming unconfirmed transactions if they are broadcasted across the P2P network while Wasabi is online. If Wasabi was offline when the transactions were broadcasted, then they will only show up after receiving their first confirmation.

--- a/docs/using-wasabi/Receive.md
+++ b/docs/using-wasabi/Receive.md
@@ -119,3 +119,5 @@ Wasabi doesn't care about why you transact with bitcoins, it only cares about wh
 ## Unconfirmed transactions
 
 Wasabi will be aware of incoming unconfirmed transactions if they are broadcasted across the P2P network while Wasabi is online. If Wasabi was offline when the transactions were broadcasted, then they will only show up after receiving their first confirmation.
+
+Unconfirmed transactions are automatically dropped from the mempool after 30 days (default setting).

--- a/docs/using-wasabi/Receive.md
+++ b/docs/using-wasabi/Receive.md
@@ -118,6 +118,6 @@ Wasabi doesn't care about why you transact with bitcoins, it only cares about wh
 
 ## Unconfirmed transactions
 
-Wasabi will be aware of incoming unconfirmed transactions if they are broadcasted across the P2P network while Wasabi is online. If Wasabi was offline when the transactions were broadcasted, then they will only show up after receiving their first confirmation.
+Wasabi will be aware of an incoming unconfirmed transaction if it is broadcasted across the P2P network while Wasabi is online. If the transaction was broadcasted while Wasabi was offline, it will only show up after receiving its first confirmation.
 
 Unconfirmed transactions are automatically dropped from the mempool after 30 days (default setting).


### PR DESCRIPTION
seems worthy to mention. 

also closes https://github.com/WalletWasabi/WasabiDoc/issues/1921

Should probably remove other sections like _## Bitcoin public keys and addresses_, which is general info nobody cares about.